### PR TITLE
u-boot-imx: clean up environment and configuration for a more production like setting

### DIFF
--- a/recipes-bsp/u-boot-imx/u-boot-imx/0003-GWC_HPC_config_cleanup.patch
+++ b/recipes-bsp/u-boot-imx/u-boot-imx/0003-GWC_HPC_config_cleanup.patch
@@ -55,7 +55,7 @@ diff -ruN a/configs/imx8xq_icore_defconfig b/configs/imx8xq_icore_defconfig
  CONFIG_CMD_DEKBLOB=y
 diff -ruN a/include/configs/imx8x_icore.h b/include/configs/imx8x_icore.h
 --- a/include/configs/imx8x_icore.h	2022-06-18 04:39:19.955253309 +0200
-+++ b/include/configs/imx8x_icore.h	2022-06-25 10:14:27.086562903 +0200
++++ b/include/configs/imx8x_icore.h	2022-06-28 03:59:43.748673963 +0200
 @@ -81,52 +81,10 @@
  	"emmc_dev=0\0" \
  	"sd_dev=1\0" \
@@ -109,7 +109,7 @@ diff -ruN a/include/configs/imx8x_icore.h b/include/configs/imx8x_icore.h
  	AHAB_ENV \
  	"script=boot.scr\0" \
  	"image=Image\0" \
-@@ -202,22 +160,18 @@
+@@ -202,22 +160,12 @@
  
  #define CONFIG_BOOTCOMMAND \
  	   "mmc dev ${mmcdev}; if mmc rescan; then " \
@@ -127,17 +127,10 @@ diff -ruN a/include/configs/imx8x_icore.h b/include/configs/imx8x_icore.h
 -				   "else run netboot; " \
 -				   "fi; " \
 -			 "fi; " \
--		   "fi; " \
++		   "if run loadcntr; then " \
++			   "run mmcboot; " \
+ 		   "fi; " \
 -	   "else booti ${loadaddr} - ${fdt_addr}; fi"
-+		   "if test ${sec_boot} = yes; then " \
-+			   "if run loadcntr; then " \
-+				   "run mmcboot; " \
-+			   "fi; " \
-+		    "else " \
-+			   "if run loadimage; then " \
-+				   "run mmcboot; " \
-+			   "fi; " \
-+		    "fi; " \
 +		"else " \
 +			"echo WARN: Error scanning MMC; " \
 +		"fi; "

--- a/recipes-bsp/u-boot-imx/u-boot-imx/0003-GWC_HPC_config_cleanup.patch
+++ b/recipes-bsp/u-boot-imx/u-boot-imx/0003-GWC_HPC_config_cleanup.patch
@@ -1,0 +1,146 @@
+diff -ruN a/configs/imx8xq_icore_defconfig b/configs/imx8xq_icore_defconfig
+--- a/configs/imx8xq_icore_defconfig	2022-06-18 04:39:20.025253290 +0200
++++ b/configs/imx8xq_icore_defconfig	2022-06-25 09:49:56.642363115 +0200
+@@ -111,17 +111,17 @@
+ CONFIG_DM_THERMAL=y
+ CONFIG_IMX_SCU_THERMAL=y
+ 
+-CONFIG_SPI=y
+-CONFIG_NXP_FSPI=y
+-CONFIG_DM_SPI=y
+-CONFIG_DM_SPI_FLASH=y
+-CONFIG_SPI_FLASH=y
+-CONFIG_SPI_FLASH_STMICRO=y
+-CONFIG_CMD_SF=y
+-CONFIG_SF_DEFAULT_BUS=0
+-CONFIG_SF_DEFAULT_CS=0
+-CONFIG_SF_DEFAULT_SPEED=40000000
+-CONFIG_SF_DEFAULT_MODE=0
++# CONFIG_SPI=y
++# CONFIG_NXP_FSPI=y
++# CONFIG_DM_SPI=y
++# CONFIG_DM_SPI_FLASH=y
++# CONFIG_SPI_FLASH=y
++# CONFIG_SPI_FLASH_STMICRO=y
++# CONFIG_CMD_SF=y
++# CONFIG_SF_DEFAULT_BUS=0
++# CONFIG_SF_DEFAULT_CS=0
++# CONFIG_SF_DEFAULT_SPEED=40000000
++# CONFIG_SF_DEFAULT_MODE=0
+ 
+ CONFIG_USB_XHCI_HCD=y
+ CONFIG_USB_XHCI_IMX8=y
+@@ -175,14 +175,14 @@
+ CONFIG_IMX_SNVS_SEC_SC=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
+ 
+-CONFIG_VIDEO_IMXDPUV1=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_IMX8_LVDS=y
+-CONFIG_VIDEO_IT6263_BRIDGE=y
+-CONFIG_SYS_WHITE_ON_BLACK=y
+-CONFIG_SPLASH_SCREEN=y
+-CONFIG_SPLASH_SCREEN_ALIGN=y
+-CONFIG_CMD_BMP=y
++# CONFIG_VIDEO_IMXDPUV1=y
++# CONFIG_DM_VIDEO=y
++# CONFIG_VIDEO_IMX8_LVDS=y
++# CONFIG_VIDEO_IT6263_BRIDGE=y
++# CONFIG_SYS_WHITE_ON_BLACK=y
++# CONFIG_SPLASH_SCREEN=y
++# CONFIG_SPLASH_SCREEN_ALIGN=y
++# CONFIG_CMD_BMP=y
+ 
+ CONFIG_AHAB_BOOT=y
+ CONFIG_CMD_DEKBLOB=y
+diff -ruN a/include/configs/imx8x_icore.h b/include/configs/imx8x_icore.h
+--- a/include/configs/imx8x_icore.h	2022-06-18 04:39:19.955253309 +0200
++++ b/include/configs/imx8x_icore.h	2022-06-25 10:14:27.086562903 +0200
+@@ -81,52 +81,10 @@
+ 	"emmc_dev=0\0" \
+ 	"sd_dev=1\0" \
+ 
+-#define JAILHOUSE_ENV \
+-	"jh_mmcboot=" \
+-		"setenv fdt_file imx8x-icore.dtb;"\
+-		"setenv boot_os 'scu_rm dtb ${fdt_addr}; booti ${loadaddr} - ${fdt_addr};'; " \
+-		"run mmcboot; \0" \
+-	"jh_netboot=" \
+-		"setenv fdt_file imx8x-icore.dtb;"\
+-		"setenv boot_os 'scu_rm dtb ${fdt_addr}; booti ${loadaddr} - ${fdt_addr};'; " \
+-		"run netboot; \0"
+-
+-#define XEN_BOOT_ENV \
+-            "xenhyper_bootargs=console=dtuart dtuart=/serial@5a060000 dom0_mem=1024M dom0_max_vcpus=2 dom0_vcpus_pin=true\0" \
+-            "xenlinux_bootargs= \0" \
+-            "xenlinux_console=hvc0 earlycon=xen\0" \
+-            "xenlinux_addr=0x9e000000\0" \
+-            "dom0fdt_file=imx8qxp-mek-dom0.dtb\0" \
+-            "xenboot_common=" \
+-                "${get_cmd} ${loadaddr} xen;" \
+-                "${get_cmd} ${fdt_addr} ${dom0fdt_file};" \
+-                "${get_cmd} ${xenlinux_addr} ${image};" \
+-                "fdt addr ${fdt_addr};" \
+-                "fdt resize 256;" \
+-                "fdt set /chosen/module@0 reg <0x00000000 ${xenlinux_addr} 0x00000000 0x${filesize}>; " \
+-                "fdt set /chosen/module@0 bootargs \"${bootargs} ${xenlinux_bootargs}\"; " \
+-                "setenv bootargs ${xenhyper_bootargs};" \
+-                "booti ${loadaddr} - ${fdt_addr};" \
+-            "\0" \
+-            "xennetboot=" \
+-                "setenv get_cmd dhcp;" \
+-                "setenv console ${xenlinux_console};" \
+-                "run netargs;" \
+-                "run xenboot_common;" \
+-            "\0" \
+-            "xenmmcboot=" \
+-                "setenv get_cmd \"fatload mmc ${mmcdev}:${mmcpart}\";" \
+-                "setenv console ${xenlinux_console};" \
+-                "run mmcargs;" \
+-                "run xenboot_common;" \
+-            "\0" \
+-
+ /* Initial environment variables */
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+ 	CONFIG_MFG_ENV_SETTINGS \
+ 	M4_BOOT_ENV \
+-	XEN_BOOT_ENV \
+-	JAILHOUSE_ENV\
+ 	AHAB_ENV \
+ 	"script=boot.scr\0" \
+ 	"image=Image\0" \
+@@ -202,22 +160,18 @@
+ 
+ #define CONFIG_BOOTCOMMAND \
+ 	   "mmc dev ${mmcdev}; if mmc rescan; then " \
+-		   "if run loadbootscript; then " \
+-			   "run bootscript; " \
+-		   "else " \
+-			   "if test ${sec_boot} = yes; then " \
+-				   "if run loadcntr; then " \
+-					   "run mmcboot; " \
+-				   "else run netboot; " \
+-				   "fi; " \
+-			    "else " \
+-				   "if run loadimage; then " \
+-					   "run mmcboot; " \
+-				   "else run netboot; " \
+-				   "fi; " \
+-			 "fi; " \
+-		   "fi; " \
+-	   "else booti ${loadaddr} - ${fdt_addr}; fi"
++		   "if test ${sec_boot} = yes; then " \
++			   "if run loadcntr; then " \
++				   "run mmcboot; " \
++			   "fi; " \
++		    "else " \
++			   "if run loadimage; then " \
++				   "run mmcboot; " \
++			   "fi; " \
++		    "fi; " \
++		"else " \
++			"echo WARN: Error scanning MMC; " \
++		"fi; "
+ 
+ /* Link Definitions */
+ #define CONFIG_LOADADDR			0x80280000

--- a/recipes-bsp/u-boot-imx/u-boot-imx_2021.04.bbappend
+++ b/recipes-bsp/u-boot-imx/u-boot-imx_2021.04.bbappend
@@ -6,3 +6,4 @@ SRC_URI += "file://0001-Add-Engicam-patches-for-Engicam-boards-supports.patch "
 # Patches to be added when SecureBoot is enabled
 SRC_URI:append:csfsigned = " file://0002-GWC_HPC_customizations.patch "
 
+SRC_URI:append = " file://0003-GWC_HPC_config_cleanup.patch "


### PR DESCRIPTION

- Removed a few really unneeded features in UBoot (SPI flash and Video)
- Cleaned up environment removing really unneded things (ie. XEN and Jailhouse)
- Sec-boot like default boot command with no fallback in case of auth error

pinging @fedefrancescon for review