### PR TITLE
Removed  kernel `Image` from installed files

### DIFF
--- a/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
+++ b/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
@@ -28,7 +28,7 @@ do_install:append:csfsigned() {
          # This would be better to have it in a do_deploy I believe
          cp os_cntr_signed.bin ${DEPLOY_DIR_IMAGE}
          # Delete unsigned image now, so it will not be packed in image-image automatically
-         rm ${D}/boot/Image-*
+         rm ${D}/boot/Image*
       fi
     fi
 }


### PR DESCRIPTION
Image Is Still present in `/boot/Image` as A symlink to `Image-[...]` that doesn't exist, making the tar extraction to exit with an error. This (should?) remove it and make the extraction successfull.