### PR TITLE
Fix kernel `do_install` not singing kernel image

### DIFF
--- a/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
+++ b/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
@@ -19,7 +19,7 @@ do_install:append:csfsigned() {
          # Copy CSF configuration part
          cp ${WORKDIR}/csf_linux_img.txt ${CSFPATH}
          # Create container with kernel and DTB
-         ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/mkimage_imx8.csf -soc QX -rev B0 -c -ap arch/arm64/boot/Image a53 0x80280000 --data arch/arm64/boot/dts/engicam/imx8xq-icore-starterkit.dtb a53 0x83000000 -out ${CSFPATH}/flash_os.bin
+         ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/mkimage_imx8 -soc QX -rev B0 -c -ap arch/arm64/boot/Image a53 0x80280000 --data arch/arm64/boot/dts/engicam/imx8xq-icore-starterkit.dtb a53 0x83000000 -out ${CSFPATH}/flash_os.bin
          # Sign image in container with CSF tool
          cd ${CSFPATH}
          ./linux64/bin/cst -i csf_linux_img.txt -o os_cntr_signed.bin


### PR DESCRIPTION
With a full rebuild from scratch I noticed kernel `do_install` failed signing the kernel image.
`mkimage_imx8.csf` doesn't exists, it should be `mkimage_imx8`. This seems to be broken since 24 Aug.
Probably we didn't noticed before because we were using "cached" tools build.
