### PR TITLE
keyctl-caam: fix SRC_URI

### DIFF
--- a/recipes-bsp/keyctl-caam/keyctl-caam_git.bb
+++ b/recipes-bsp/keyctl-caam/keyctl-caam_git.bb
@@ -5,7 +5,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8636bd68fc00cc6a3809b7b58b45f982"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-SRC_URI = "git://source.codeaurora.org/external/imx/keyctl_caam;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/nxp-imx/keyctl_caam;branch=${SRCBRANCH}"
 SRCREV = "6b80882e3d5bc986a1f2f9512845170658ba9ea2"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
NXP moved lots of its stuff from codeaurora to github, so we need to move the reference as well

@fedefrancescon : FYI!