### PR TITLE
feat: added rsyslog in place of busybox-syslog

### DIFF
--- a/conf/machine/imx8xq-smarcore.conf
+++ b/conf/machine/imx8xq-smarcore.conf
@@ -119,3 +119,6 @@ RPM_GPG_NAME = "<KEY HERE>"
 RPM_GPG_PASSPHRASE = "<PASS HERE>"
 # GPG_PATH = "/directory/with/gpg/data"
 IMAGE_INSTALL:append = " signing-keys-rpm"
+
+# Make rsyslog our default logger
+VIRTUAL-RUNTIME_base-utils-syslog = "rsyslog"

--- a/recipes-extended/rsyslog/rsyslog_8.2206.0.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_8.2206.0.bbappend
@@ -1,0 +1,16 @@
+PR = "r1"
+
+# We don't want silly logrotate deps
+# As no one is currently using it
+# The same is valid for systemd service
+# as we provide our-own
+RDEPENDS:${PN}:remove = "logrotate"
+RCONFLICTS:${PN} = ""
+SYSTEMD_SERVICE:${PN} = ""
+
+# Removing some not needed files
+# (logrotate, conf and systemd services)
+do_install:append() {
+  rm -rf "${D}/etc" \
+         "${D}/lib"
+}

--- a/recipes-extended/rsyslog/rsyslog_8.2206.0.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_8.2206.0.bbappend
@@ -11,6 +11,6 @@ SYSTEMD_SERVICE:${PN} = ""
 # Removing some not needed files
 # (logrotate, conf and systemd services)
 do_install:append() {
-  rm -rf "${D}/etc" \
+  rm -rf "${D}${sysconfdir}" \
          "${D}/lib"
 }

--- a/recipes-images/images/engicam-gwc.bb
+++ b/recipes-images/images/engicam-gwc.bb
@@ -105,8 +105,6 @@ IMAGE_INSTALL:append = " \
 	libedit \
 	gpsd \
 	libgps \
-        libestr \
-        libfastjson \
 	rsyslog \
 "
 

--- a/recipes-images/images/engicam-gwc.bb
+++ b/recipes-images/images/engicam-gwc.bb
@@ -105,6 +105,9 @@ IMAGE_INSTALL:append = " \
 	libedit \
 	gpsd \
 	libgps \
+        libestr \
+        libfastjson \
+	rsyslog \
 "
 
 # NOTE: lighttpd-mod-compress -> lighttpd-mod-deflate https://redmine.lighttpd.net/projects/1/wiki/docs_modcompress

--- a/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
+++ b/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
@@ -1,8 +1,0 @@
-PR="r1"
-
-# fail2ban has an explicit dependency on busybox-syslog
-# which, in turn, conflicts with rsyslog. 
-# we'd have to forcibly remove it or the newer gwc core
-# won't be installable.
-VIRTUAL-RUNTIME_syslog = ""
-VIRTUAL-RUNTIME_base-utils-syslog = ""

--- a/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
+++ b/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
@@ -2,7 +2,7 @@ PR="r1"
 
 # fail2ban has an explicit dependency on busybox-syslog
 # which, in turn, conflicts with rsyslog. 
-# we'd have to forcibli remove it or the newer gwc core
+# we'd have to forcibly remove it or the newer gwc core
 # won't be installable.
 VIRTUAL-RUNTIME_syslog = ""
 VIRTUAL-RUNTIME_base-utils-syslog = ""

--- a/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
+++ b/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
@@ -1,0 +1,8 @@
+PR="r1"
+
+# fail2ban has an explicit dependency on busybox-syslog
+# which, in turn, conflicts with rsyslog. 
+# we'd have to forcibli remove it or the newer gwc core
+# won't be installable.
+VIRTUAL-RUNTIME_syslog = ""
+VIRTUAL-RUNTIME_base-utils-syslog = ""

--- a/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
+++ b/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
@@ -6,9 +6,3 @@ PR="r1"
 # won't be installable.
 VIRTUAL-RUNTIME_syslog = ""
 VIRTUAL-RUNTIME_base-utils-syslog = ""
-
-# moving fail2ban conf to avoid overwriting gwc-conf
-do_install:append() {
-  mv "${D}/etc/fail2ban/fail2ban.conf" \
-     "${D}/etc/fail2ban/fail2ban.conf.dist"
-}

--- a/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
+++ b/recipes-security/fail2ban/python3-fail2ban_0.11.2.bbappend
@@ -6,3 +6,9 @@ PR="r1"
 # won't be installable.
 VIRTUAL-RUNTIME_syslog = ""
 VIRTUAL-RUNTIME_base-utils-syslog = ""
+
+# moving fail2ban conf to avoid overwriting gwc-conf
+do_install:append() {
+  mv "${D}/etc/fail2ban/fail2ban.conf" \
+     "${D}/etc/fail2ban/fail2ban.conf.dist"
+}


### PR DESCRIPTION
Added rsyslog to allow remote log forwarding.  
python3-fail2ban used to require `busybox-syslog` which conflicts with `rsyslog`

Polished both packages to avoid not needed files and conflicts