### PR TITLE
Various fixes to fix compatibilities with latest upstream Kirkstone

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.4.bbappend
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bbappend
@@ -1,4 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-mx8m-mini-remove-uart4-from-m4.patch"
+# Update 01/2025: moved (quite some time ago) from Aurora to Github
+SRC_URI = "git://github.com/nxp-imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-mx8m-mini-remove-uart4-from-m4.patch"
 

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bbappend
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bbappend
@@ -1,0 +1,13 @@
+
+
+# Update 01/2025: moved (quite some time ago) from Aurora to Github
+# Note: As there are many patches, we need to expliclty say here them again, see overridden
+# recipe in meta-freescale/recipes-bsp/imx-mkimage
+SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH}"
+           file://0001-mkimage_fit_atf-fix-fit-generator-node-naming.patch \
+           file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
+           file://0001-Add-support-for-overriding-BL32-and-BL33-not-only-BL.patch \
+           file://0001-Add-LDFLAGS-to-link-step.patch \
+           file://0001-Add-support-for-overriding-BL31-BL32-and-BL33.patch \
+"
+

--- a/recipes-bsp/u-boot-imx/u-boot-imx_2021.04.bbappend
+++ b/recipes-bsp/u-boot-imx/u-boot-imx_2021.04.bbappend
@@ -1,7 +1,10 @@
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Add-Engicam-patches-for-Engicam-boards-supports.patch "
+
+# Update 01/2025: moved (quite some time ago) from Aurora to Github
+SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-Add-Engicam-patches-for-Engicam-boards-supports.patch "
 
 # Patches to be added when SecureBoot is enabled
 SRC_URI:append:csfsigned = " file://0002-GWC_HPC_customizations.patch "

--- a/recipes-core/meta/signing-keys.bbappend
+++ b/recipes-core/meta/signing-keys.bbappend
@@ -1,0 +1,3 @@
+
+# See also https://git.yoctoproject.org/poky/commit/meta/recipes-core/meta/signing-keys.bb?id=ffc3051d09ce85c626301addef9704610ef2b24f
+RDEPENDS:${PN}-dev = ""

--- a/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
+++ b/recipes-kernel/linux-fslc-imx/linux-fslc-imx_5.10.bbappend
@@ -7,6 +7,21 @@ SRC_URI += "file://0001-Add_Engicam_dts.patch file://0002-Add-customized-DTS-for
 PV = "${LINUX_VERSION}-HSC-1"
 PR = "r1"
 
+# After last (end of 2024) poky upgrade we had RPM packages that had a different version
+# name due to various changes (in a stable / maintenance branch ???) in kernel version
+# management in Yocto. See (in time order, note some override/delete each other):
+# - https://git.yoctoproject.org/poky/commit/meta/classes?h=kirkstone&id=552288e0c83084097cf38611bd82315aa9d892df
+# - https://git.yoctoproject.org/poky/commit/meta/classes?h=kirkstone&id=0b39955d14600257a6eafc211fd68a933c69a0e9
+# - https://git.yoctoproject.org/poky/commit/meta/classes?h=kirkstone&id=57b8a1adb54a3adab22f4e04ced66a92ffc78a96
+# - https://git.yoctoproject.org/poky/commit/meta/classes?h=kirkstone&id=2b7c113459a602c91badaa7543d02811feac0151
+# - https://git.yoctoproject.org/poky/commit/meta/classes?h=kirkstone&id=26f23535eef1f3314c42cd00cda0c6da7cdaf9af
+# Setting local version as below is a half-hack to guarantee generated RPMs are named the
+# same as before, so dnf update will work correctly (otherwise we would need to remove and
+# then install packages which would be annoying and risky)
+# (it is set to "+" as this was generated, as can be deduced from commits above, due to
+# local changes present, ie. patches we apply, and git reporting them)
+LOCALVERSION = "+"
+
 # Additional parts to generate container and sign it (if csfsigned override is present)
 # See also imx-boot recipe for more details!
 DEPENDS:csfsigned += "imx-boot openssl-native"


### PR DESCRIPTION
Includes:
- Fix change of kernel RPM name (make it same as before, so dnf update will work) due to upstream introducing changes around this
- Fix references of used packages to aurora repository which is gone since some time and replace with equivalent on NXP github
- Backport fix for signing RPM generation for SDK (was contributed long time ago but was just merged into master)