### PR TITLE
fix(dts): RS485 uart1 set rts to active-high

### DIFF
--- a/recipes-kernel/linux-fslc-imx/linux-fslc-imx/0001-Add_Engicam_HSC_dts.patch
+++ b/recipes-kernel/linux-fslc-imx/linux-fslc-imx/0001-Add_Engicam_HSC_dts.patch
@@ -251,7 +251,7 @@ diff -ruN a/arch/arm64/boot/dts/engicam/imx8xq-icore-starterkit.dts b/arch/arm64
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&pinctrl_lpuart1>;
 +	fsl,uart-has-rtscts;
-+	rs485-rts-active-low;
++	rs485-rts-active-high;
 +	linux,rs485-enabled-at-boot-time;
 +	status = "okay";
 +};


### PR DESCRIPTION
uart1 has RTS as `active-high`   
Apparently with the old kernel this parameter was ignored somehow